### PR TITLE
Speed up commuting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1581,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1909,7 @@ dependencies = [
  "prost-build",
  "rand",
  "rand_distr",
+ "rayon",
  "reqwest",
  "rstar",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ proj = "0.20.5"
 prost = "0.9.0"
 rand = "0.8.4"
 rand_distr = "0.4.2"
+rayon = "1.5.1"
 reqwest = { version = "0.11.8", features = ["stream"] }
 rstar = "0.8.4"
 serde = { version = "1.0.132", features = ["derive"] }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,19 +5,23 @@ The following tables summarizes the resources SPC needs to run in different area
 +---------------------------------------------------------------------------------------------------------------+
 |     study_area     |num_msoas|num_households|num_people|pb_file_size|  runtime |commuting_runtime|memory_usage|
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|west_yorkshire_large|   299   |    954,106   | 1,961,027| 1009.65MiB | 3 minutes|    3 minutes    |   1.53GiB  |
+|west_yorkshire_large|   299   |    954,106   | 1,961,027| 1009.78MiB |74 seconds|    26 seconds   |   1.53GiB  |
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|       london       |   983   |   3,076,198  | 6,289,513|   3.19GiB  |57 minutes|    55 minutes   |   5.33GiB  |
+|       london       |   983   |   3,076,198  | 6,289,513|   3.19GiB  | 8 minutes|    6 minutes    |   5.35GiB  |
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|        devon       |   107   |    345,882   |  679,259 |  352.95MiB |47 seconds|    25 seconds   |  631.73MiB |
+|        leeds       |   107   |    331,059   |  671,416 |  347.08MiB |31 seconds|    7 seconds    |  628.50MiB |
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|    two_counties    |    4    |    13,958    |  27,028  |  14.19MiB  |10 seconds|     1 second    |  25.27MiB  |
+|        devon       |   107   |    345,882   |  679,259 |  353.06MiB |27 seconds|    6 seconds    |  632.97MiB |
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|    two_counties    |    4    |    13,958    |  27,028  |  14.19MiB  |10 seconds|     1 second    |  25.27MiB  |
+|    two_counties    |    4    |    13,958    |  27,028  |  14.20MiB  |10 seconds|     1 second    |  25.40MiB  |
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|       bristol      |    55   |    193,873   |  394,739 |  204.39MiB |17 seconds|    4 seconds    |  344.48MiB |
+|    two_counties    |    4    |    13,958    |  27,028  |  14.20MiB  |10 seconds|     1 second    |  25.40MiB  |
 +--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
-|west_yorkshire_small|    3    |    11,033    |  23,575  |  12.40MiB  | 7 seconds|     1 second    |  23.49MiB  |
+|       bristol      |    55   |    193,873   |  394,739 |  204.51MiB |14 seconds|    2 seconds    |  345.19MiB |
++--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
+|west_yorkshire_small|    3    |    11,033    |  23,575  |  12.40MiB  | 6 seconds|     1 second    |  23.60MiB  |
++--------------------+---------+--------------+----------+------------+----------+-----------------+------------+
+|      liverpool     |    61   |    216,559   |  405,738 |  209.54MiB |15 seconds|    3 seconds    |  350.06MiB |
 +---------------------------------------------------------------------------------------------------------------+
 
 Notes:
@@ -26,4 +30,5 @@ Notes:
 - The total `runtime` is usually dominated by matching workers to businesses, so `commuting_runtime` gives a breakdown
 - Measuring memory usage of Linux processes isn't straightforward, so `memory_usage` should just be a guide
 - These measurements were all taken on one developer's laptop, and they don't represent multiple runs. This table just aims to give a general sense of how long running takes.
+  - That machine has 16 cores, which matters for the parallelized commuting calculation.
 - `scripts/collect_stats.py` produces the table above

--- a/scripts/collect_stats.py
+++ b/scripts/collect_stats.py
@@ -9,7 +9,7 @@ from markdownTable import markdownTable
 
 rows = []
 for study_area in listdir("config"):
-    if study_area == "national":
+    if study_area == "national.csv":
         continue
     # Assume `cargo build --release` has happened
     subprocess.run(["./target/release/spc", "config/" + study_area, "--output-stats"])

--- a/src/init/commuting.rs
+++ b/src/init/commuting.rs
@@ -225,11 +225,6 @@ impl JobMarket {
         businesses: &Businesses,
         pb: ProgressBar,
     ) -> Vec<(PersonID, VenueID)> {
-        /*if let Some(sic) = self.sic {
-            info!("Assigning workplaces for SIC {sic}");
-        } else {
-            info!("Assigning workplaces for everyone, ignoring SIC");
-        }*/
         assert_eq!(self.jobs.len(), self.workers.len());
 
         let mut choices: Vec<(VenueID, usize)> = self.to_job_choices();


### PR DESCRIPTION
For #4 
I'm collecting stats for all study areas now, but the preview: commuting calculation for west_yorkshire_large drops from > 3 minutes down to 25 seconds. The multiple progress bars proceeding in parallel tell the story even better:

https://user-images.githubusercontent.com/1664407/162966376-bc617a24-3742-465e-b887-60b036ee5f61.mp4

The two tricks are to match jobs/workers in parallel by SIC, and to remove a layer of indirection when initially dealing with businesses (leading to slightly cache-friendlier representation and not having to spam a hashmap with lookups.