### PR TITLE
Stop copying per-MSOA flows to each person in the MSOA. This is hugely

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,14 +4,14 @@ The following tables summarizes the resources SPC needs to run in different area
 
 |     study_area     |num_msoas|num_households|num_people|pb_file_size|  runtime |commuting_runtime|memory_usage|
 |--------------------|---------|--------------|----------|------------|----------|-----------------|------------|
-|       bristol      |    55   |    193,873   |  394,739 |  204.51MiB |14 seconds|    2 seconds    |  345.19MiB |
-|        devon       |   107   |    345,882   |  679,259 |  353.06MiB |27 seconds|    6 seconds    |  632.97MiB |
-|        leeds       |   107   |    331,059   |  671,416 |  347.08MiB |31 seconds|    7 seconds    |  628.50MiB |
-|      liverpool     |    61   |    216,559   |  405,738 |  209.54MiB |15 seconds|    3 seconds    |  350.06MiB |
-|       london       |   983   |   3,076,198  | 6,289,513|   3.19GiB  | 8 minutes|    6 minutes    |   5.35GiB  |
-|    two_counties    |    4    |    13,958    |  27,028  |  14.20MiB  |10 seconds|     1 second    |  25.40MiB  |
-|west_yorkshire_small|    3    |    11,033    |  23,575  |  12.40MiB  | 6 seconds|     1 second    |  23.60MiB  |
-|west_yorkshire_large|   299   |    954,106   | 1,961,027| 1009.78MiB |74 seconds|    26 seconds   |   1.53GiB  |
+|       bristol      |    55   |    193,873   |  394,739 |  61.99MiB  | 5 seconds|     1 second    |  141.45MiB |
+|        devon       |   107   |    345,882   |  679,259 |  105.22MiB |16 seconds|    6 seconds    |  277.20MiB |
+|        leeds       |   107   |    331,059   |  671,416 |  104.60MiB |20 seconds|    7 seconds    |  276.95MiB |
+|      liverpool     |    61   |    216,559   |  405,738 |  61.08MiB  | 9 seconds|    3 seconds    |  140.54MiB |
+|       london       |   983   |   3,076,198  | 6,289,513|  969.80MiB | 7 minutes|    6 minutes    |   2.17GiB  |
+|    two_counties    |    4    |    13,958    |  27,028  |   4.49MiB  |10 seconds|     1 second    |  11.55MiB  |
+|west_yorkshire_large|   299   |    954,106   | 1,961,027|  301.93MiB |41 seconds|    25 seconds   |  563.91MiB |
+|west_yorkshire_small|    3    |    11,033    |  23,575  |   4.00MiB  | 7 seconds|     1 second    |  11.42MiB  |
 
 Notes:
 

--- a/protobuf_samples/synthpop_pb2.py
+++ b/protobuf_samples/synthpop_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='synthpop',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x0esynthpop.proto\x12\x08synthpop\"\x9f\x03\n\nPopulation\x12\'\n\nhouseholds\x18\x01 \x03(\x0b\x32\x13.synthpop.Household\x12 \n\x06people\x18\x02 \x03(\x0b\x32\x10.synthpop.Person\x12H\n\x13venues_per_activity\x18\x03 \x03(\x0b\x32+.synthpop.Population.VenuesPerActivityEntry\x12<\n\rinfo_per_msoa\x18\x04 \x03(\x0b\x32%.synthpop.Population.InfoPerMsoaEntry\x12$\n\x08lockdown\x18\x05 \x01(\x0b\x32\x12.synthpop.Lockdown\x1aM\n\x16VenuesPerActivityEntry\x12\x0b\n\x03key\x18\x01 \x01(\x05\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.synthpop.VenueList:\x02\x38\x01\x1aI\n\x10InfoPerMsoaEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.synthpop.InfoPerMSOA:\x02\x38\x01\"H\n\tHousehold\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x0c\n\x04msoa\x18\x02 \x01(\t\x12\x10\n\x08orig_hid\x18\x03 \x01(\x03\x12\x0f\n\x07members\x18\x04 \x03(\x04\",\n\tVenueList\x12\x1f\n\x06venues\x18\x01 \x03(\x0b\x32\x0f.synthpop.Venue\"e\n\x0bInfoPerMSOA\x12\x1e\n\x05shape\x18\x01 \x03(\x0b\x32\x0f.synthpop.Point\x12\x12\n\npopulation\x18\x02 \x01(\x04\x12\"\n\tbuildings\x18\x03 \x03(\x0b\x32\x0f.synthpop.Point\",\n\x05Point\x12\x11\n\tlongitude\x18\x01 \x01(\x02\x12\x10\n\x08latitude\x18\x02 \x01(\x02\"\xfe\x01\n\x06Person\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x11\n\thousehold\x18\x02 \x01(\x04\x12!\n\x08location\x18\x03 \x01(\x0b\x32\x0f.synthpop.Point\x12\x10\n\x08orig_pid\x18\x04 \x01(\x03\x12,\n\x0c\x64\x65mographics\x18\x05 \x01(\x0b\x32\x16.synthpop.Demographics\x12 \n\x06health\x18\x06 \x01(\x0b\x32\x10.synthpop.Health\x12#\n\x08time_use\x18\x07 \x01(\x0b\x32\x11.synthpop.TimeUse\x12+\n\x12\x66lows_per_activity\x18\x08 \x03(\x0b\x32\x0f.synthpop.Flows\"\xa8\x01\n\x0c\x44\x65mographics\x12\x1a\n\x03sex\x18\x01 \x01(\x0e\x32\r.synthpop.Sex\x12\x11\n\tage_years\x18\x02 \x01(\r\x12 \n\x06origin\x18\x03 \x01(\x0e\x32\x10.synthpop.Origin\x12\x36\n\x1csocioeconomic_classification\x18\x04 \x01(\x0e\x32\x10.synthpop.NSSEC5\x12\x0f\n\x07sic1d07\x18\x05 \x01(\x04\"\x7f\n\x06Health\x12\x1a\n\x03\x62mi\x18\x01 \x01(\x0e\x32\r.synthpop.BMI\x12\"\n\x1ahas_cardiovascular_disease\x18\x02 \x01(\x08\x12\x14\n\x0chas_diabetes\x18\x03 \x01(\x08\x12\x1f\n\x17has_high_blood_pressure\x18\x04 \x01(\x08\"\xd3\x01\n\x07TimeUse\x12\x0f\n\x07unknown\x18\x01 \x01(\x01\x12\x0c\n\x04work\x18\x02 \x01(\x01\x12\x0e\n\x06school\x18\x03 \x01(\x01\x12\x0c\n\x04shop\x18\x04 \x01(\x01\x12\x10\n\x08services\x18\x05 \x01(\x01\x12\x0f\n\x07leisure\x18\x06 \x01(\x01\x12\x0e\n\x06\x65scort\x18\x07 \x01(\x01\x12\x11\n\ttransport\x18\x08 \x01(\x01\x12\x10\n\x08not_home\x18\t \x01(\x01\x12\x0c\n\x04home\x18\n \x01(\x01\x12\x11\n\twork_home\x18\x0b \x01(\x01\x12\x12\n\nhome_total\x18\x0c \x01(\x01\"g\n\x05\x46lows\x12$\n\x08\x61\x63tivity\x18\x01 \x01(\x0e\x32\x12.synthpop.Activity\x12\x1d\n\x05\x66lows\x18\x02 \x03(\x0b\x32\x0e.synthpop.Flow\x12\x19\n\x11\x61\x63tivity_duration\x18\x03 \x01(\x01\"(\n\x04\x46low\x12\x10\n\x08venue_id\x18\x01 \x01(\x04\x12\x0e\n\x06weight\x18\x02 \x01(\x01\"i\n\x05Venue\x12\n\n\x02id\x18\x01 \x01(\x04\x12$\n\x08\x61\x63tivity\x18\x02 \x01(\x0e\x32\x12.synthpop.Activity\x12!\n\x08location\x18\x03 \x01(\x0b\x32\x0f.synthpop.Point\x12\x0b\n\x03urn\x18\x04 \x01(\x04\"/\n\x08Lockdown\x12\x12\n\nstart_date\x18\x01 \x01(\t\x12\x0f\n\x07per_day\x18\x02 \x03(\x02*\x1b\n\x03Sex\x12\n\n\x06\x46\x45MALE\x10\x00\x12\x08\n\x04MALE\x10\x01*?\n\x06Origin\x12\t\n\x05WHITE\x10\x00\x12\t\n\x05\x42LACK\x10\x01\x12\t\n\x05\x41SIAN\x10\x02\x12\t\n\x05MIXED\x10\x03\x12\t\n\x05OTHER\x10\x04*Y\n\x06NSSEC5\x12\x0e\n\nUNEMPLOYED\x10\x00\x12\n\n\x06HIGHER\x10\x01\x12\x10\n\x0cINTERMEDIATE\x10\x02\x12\t\n\x05SMALL\x10\x03\x12\t\n\x05LOWER\x10\x04\x12\x0b\n\x07ROUTINE\x10\x05*m\n\x03\x42MI\x12\x12\n\x0eNOT_APPLICABLE\x10\x00\x12\x0f\n\x0bUNDERWEIGHT\x10\x01\x12\n\n\x06NORMAL\x10\x02\x12\x0e\n\nOVERWEIGHT\x10\x03\x12\x0b\n\x07OBESE_1\x10\x04\x12\x0b\n\x07OBESE_2\x10\x05\x12\x0b\n\x07OBESE_3\x10\x06*c\n\x08\x41\x63tivity\x12\n\n\x06RETAIL\x10\x00\x12\x12\n\x0ePRIMARY_SCHOOL\x10\x01\x12\x14\n\x10SECONDARY_SCHOOL\x10\x02\x12\x08\n\x04HOME\x10\x03\x12\x08\n\x04WORK\x10\x04\x12\r\n\tNIGHTCLUB\x10\x05\x62\x06proto3')
+  serialized_pb=_b('\n\x0esynthpop.proto\x12\x08synthpop\"\x9f\x03\n\nPopulation\x12\'\n\nhouseholds\x18\x01 \x03(\x0b\x32\x13.synthpop.Household\x12 \n\x06people\x18\x02 \x03(\x0b\x32\x10.synthpop.Person\x12H\n\x13venues_per_activity\x18\x03 \x03(\x0b\x32+.synthpop.Population.VenuesPerActivityEntry\x12<\n\rinfo_per_msoa\x18\x04 \x03(\x0b\x32%.synthpop.Population.InfoPerMsoaEntry\x12$\n\x08lockdown\x18\x05 \x01(\x0b\x32\x12.synthpop.Lockdown\x1aM\n\x16VenuesPerActivityEntry\x12\x0b\n\x03key\x18\x01 \x01(\x05\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.synthpop.VenueList:\x02\x38\x01\x1aI\n\x10InfoPerMsoaEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.synthpop.InfoPerMSOA:\x02\x38\x01\"H\n\tHousehold\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x0c\n\x04msoa\x18\x02 \x01(\t\x12\x10\n\x08orig_hid\x18\x03 \x01(\x03\x12\x0f\n\x07members\x18\x04 \x03(\x04\",\n\tVenueList\x12\x1f\n\x06venues\x18\x01 \x03(\x0b\x32\x0f.synthpop.Venue\"\x92\x01\n\x0bInfoPerMSOA\x12\x1e\n\x05shape\x18\x01 \x03(\x0b\x32\x0f.synthpop.Point\x12\x12\n\npopulation\x18\x02 \x01(\x04\x12\"\n\tbuildings\x18\x03 \x03(\x0b\x32\x0f.synthpop.Point\x12+\n\x12\x66lows_per_activity\x18\x04 \x03(\x0b\x32\x0f.synthpop.Flows\",\n\x05Point\x12\x11\n\tlongitude\x18\x01 \x01(\x02\x12\x10\n\x08latitude\x18\x02 \x01(\x02\"\x9c\x02\n\x06Person\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x11\n\thousehold\x18\x02 \x01(\x04\x12\x11\n\tworkplace\x18\x03 \x01(\x04\x12!\n\x08location\x18\x04 \x01(\x0b\x32\x0f.synthpop.Point\x12\x10\n\x08orig_pid\x18\x05 \x01(\x03\x12,\n\x0c\x64\x65mographics\x18\x06 \x01(\x0b\x32\x16.synthpop.Demographics\x12 \n\x06health\x18\x07 \x01(\x0b\x32\x10.synthpop.Health\x12#\n\x08time_use\x18\x08 \x01(\x0b\x32\x11.synthpop.TimeUse\x12\x36\n\x12\x61\x63tivity_durations\x18\t \x03(\x0b\x32\x1a.synthpop.ActivityDuration\"J\n\x10\x41\x63tivityDuration\x12$\n\x08\x61\x63tivity\x18\x01 \x01(\x0e\x32\x12.synthpop.Activity\x12\x10\n\x08\x64uration\x18\x02 \x01(\x01\"\xa8\x01\n\x0c\x44\x65mographics\x12\x1a\n\x03sex\x18\x01 \x01(\x0e\x32\r.synthpop.Sex\x12\x11\n\tage_years\x18\x02 \x01(\r\x12 \n\x06origin\x18\x03 \x01(\x0e\x32\x10.synthpop.Origin\x12\x36\n\x1csocioeconomic_classification\x18\x04 \x01(\x0e\x32\x10.synthpop.NSSEC5\x12\x0f\n\x07sic1d07\x18\x05 \x01(\x04\"\x7f\n\x06Health\x12\x1a\n\x03\x62mi\x18\x01 \x01(\x0e\x32\r.synthpop.BMI\x12\"\n\x1ahas_cardiovascular_disease\x18\x02 \x01(\x08\x12\x14\n\x0chas_diabetes\x18\x03 \x01(\x08\x12\x1f\n\x17has_high_blood_pressure\x18\x04 \x01(\x08\"\xd3\x01\n\x07TimeUse\x12\x0f\n\x07unknown\x18\x01 \x01(\x01\x12\x0c\n\x04work\x18\x02 \x01(\x01\x12\x0e\n\x06school\x18\x03 \x01(\x01\x12\x0c\n\x04shop\x18\x04 \x01(\x01\x12\x10\n\x08services\x18\x05 \x01(\x01\x12\x0f\n\x07leisure\x18\x06 \x01(\x01\x12\x0e\n\x06\x65scort\x18\x07 \x01(\x01\x12\x11\n\ttransport\x18\x08 \x01(\x01\x12\x10\n\x08not_home\x18\t \x01(\x01\x12\x0c\n\x04home\x18\n \x01(\x01\x12\x11\n\twork_home\x18\x0b \x01(\x01\x12\x12\n\nhome_total\x18\x0c \x01(\x01\"L\n\x05\x46lows\x12$\n\x08\x61\x63tivity\x18\x01 \x01(\x0e\x32\x12.synthpop.Activity\x12\x1d\n\x05\x66lows\x18\x02 \x03(\x0b\x32\x0e.synthpop.Flow\"(\n\x04\x46low\x12\x10\n\x08venue_id\x18\x01 \x01(\x04\x12\x0e\n\x06weight\x18\x02 \x01(\x01\"i\n\x05Venue\x12\n\n\x02id\x18\x01 \x01(\x04\x12$\n\x08\x61\x63tivity\x18\x02 \x01(\x0e\x32\x12.synthpop.Activity\x12!\n\x08location\x18\x03 \x01(\x0b\x32\x0f.synthpop.Point\x12\x0b\n\x03urn\x18\x04 \x01(\x04\"/\n\x08Lockdown\x12\x12\n\nstart_date\x18\x01 \x01(\t\x12\x0f\n\x07per_day\x18\x02 \x03(\x02*\x1b\n\x03Sex\x12\n\n\x06\x46\x45MALE\x10\x00\x12\x08\n\x04MALE\x10\x01*?\n\x06Origin\x12\t\n\x05WHITE\x10\x00\x12\t\n\x05\x42LACK\x10\x01\x12\t\n\x05\x41SIAN\x10\x02\x12\t\n\x05MIXED\x10\x03\x12\t\n\x05OTHER\x10\x04*Y\n\x06NSSEC5\x12\x0e\n\nUNEMPLOYED\x10\x00\x12\n\n\x06HIGHER\x10\x01\x12\x10\n\x0cINTERMEDIATE\x10\x02\x12\t\n\x05SMALL\x10\x03\x12\t\n\x05LOWER\x10\x04\x12\x0b\n\x07ROUTINE\x10\x05*m\n\x03\x42MI\x12\x12\n\x0eNOT_APPLICABLE\x10\x00\x12\x0f\n\x0bUNDERWEIGHT\x10\x01\x12\n\n\x06NORMAL\x10\x02\x12\x0e\n\nOVERWEIGHT\x10\x03\x12\x0b\n\x07OBESE_1\x10\x04\x12\x0b\n\x07OBESE_2\x10\x05\x12\x0b\n\x07OBESE_3\x10\x06*c\n\x08\x41\x63tivity\x12\n\n\x06RETAIL\x10\x00\x12\x12\n\x0ePRIMARY_SCHOOL\x10\x01\x12\x14\n\x10SECONDARY_SCHOOL\x10\x02\x12\x08\n\x04HOME\x10\x03\x12\x08\n\x04WORK\x10\x04\x12\r\n\tNIGHTCLUB\x10\x05\x62\x06proto3')
 )
 
 _SEX = _descriptor.EnumDescriptor(
@@ -40,8 +40,8 @@ _SEX = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1789,
-  serialized_end=1816,
+  serialized_start=1914,
+  serialized_end=1941,
 )
 _sym_db.RegisterEnumDescriptor(_SEX)
 
@@ -75,8 +75,8 @@ _ORIGIN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1818,
-  serialized_end=1881,
+  serialized_start=1943,
+  serialized_end=2006,
 )
 _sym_db.RegisterEnumDescriptor(_ORIGIN)
 
@@ -114,8 +114,8 @@ _NSSEC5 = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1883,
-  serialized_end=1972,
+  serialized_start=2008,
+  serialized_end=2097,
 )
 _sym_db.RegisterEnumDescriptor(_NSSEC5)
 
@@ -157,8 +157,8 @@ _BMI = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1974,
-  serialized_end=2083,
+  serialized_start=2099,
+  serialized_end=2208,
 )
 _sym_db.RegisterEnumDescriptor(_BMI)
 
@@ -196,8 +196,8 @@ _ACTIVITY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2085,
-  serialized_end=2184,
+  serialized_start=2210,
+  serialized_end=2309,
 )
 _sym_db.RegisterEnumDescriptor(_ACTIVITY)
 
@@ -475,6 +475,13 @@ _INFOPERMSOA = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='flows_per_activity', full_name='synthpop.InfoPerMSOA.flows_per_activity', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -487,8 +494,8 @@ _INFOPERMSOA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=566,
-  serialized_end=667,
+  serialized_start=567,
+  serialized_end=713,
 )
 
 
@@ -525,8 +532,8 @@ _POINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=669,
-  serialized_end=713,
+  serialized_start=715,
+  serialized_end=759,
 )
 
 
@@ -552,43 +559,50 @@ _PERSON = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='location', full_name='synthpop.Person.location', index=2,
-      number=3, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='orig_pid', full_name='synthpop.Person.orig_pid', index=3,
-      number=4, type=3, cpp_type=2, label=1,
+      name='workplace', full_name='synthpop.Person.workplace', index=2,
+      number=3, type=4, cpp_type=4, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='demographics', full_name='synthpop.Person.demographics', index=4,
-      number=5, type=11, cpp_type=10, label=1,
+      name='location', full_name='synthpop.Person.location', index=3,
+      number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='health', full_name='synthpop.Person.health', index=5,
+      name='orig_pid', full_name='synthpop.Person.orig_pid', index=4,
+      number=5, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='demographics', full_name='synthpop.Person.demographics', index=5,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='time_use', full_name='synthpop.Person.time_use', index=6,
+      name='health', full_name='synthpop.Person.health', index=6,
       number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='flows_per_activity', full_name='synthpop.Person.flows_per_activity', index=7,
-      number=8, type=11, cpp_type=10, label=3,
+      name='time_use', full_name='synthpop.Person.time_use', index=7,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='activity_durations', full_name='synthpop.Person.activity_durations', index=8,
+      number=9, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -605,8 +619,46 @@ _PERSON = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=716,
-  serialized_end=970,
+  serialized_start=762,
+  serialized_end=1046,
+)
+
+
+_ACTIVITYDURATION = _descriptor.Descriptor(
+  name='ActivityDuration',
+  full_name='synthpop.ActivityDuration',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='activity', full_name='synthpop.ActivityDuration.activity', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='duration', full_name='synthpop.ActivityDuration.duration', index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1048,
+  serialized_end=1122,
 )
 
 
@@ -664,8 +716,8 @@ _DEMOGRAPHICS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=973,
-  serialized_end=1141,
+  serialized_start=1125,
+  serialized_end=1293,
 )
 
 
@@ -716,8 +768,8 @@ _HEALTH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1143,
-  serialized_end=1270,
+  serialized_start=1295,
+  serialized_end=1422,
 )
 
 
@@ -824,8 +876,8 @@ _TIMEUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1273,
-  serialized_end=1484,
+  serialized_start=1425,
+  serialized_end=1636,
 )
 
 
@@ -850,13 +902,6 @@ _FLOWS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='activity_duration', full_name='synthpop.Flows.activity_duration', index=2,
-      number=3, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -869,8 +914,8 @@ _FLOWS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1486,
-  serialized_end=1589,
+  serialized_start=1638,
+  serialized_end=1714,
 )
 
 
@@ -907,8 +952,8 @@ _FLOW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1591,
-  serialized_end=1631,
+  serialized_start=1716,
+  serialized_end=1756,
 )
 
 
@@ -959,8 +1004,8 @@ _VENUE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1633,
-  serialized_end=1738,
+  serialized_start=1758,
+  serialized_end=1863,
 )
 
 
@@ -997,8 +1042,8 @@ _LOCKDOWN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1740,
-  serialized_end=1787,
+  serialized_start=1865,
+  serialized_end=1912,
 )
 
 _POPULATION_VENUESPERACTIVITYENTRY.fields_by_name['value'].message_type = _VENUELIST
@@ -1013,11 +1058,13 @@ _POPULATION.fields_by_name['lockdown'].message_type = _LOCKDOWN
 _VENUELIST.fields_by_name['venues'].message_type = _VENUE
 _INFOPERMSOA.fields_by_name['shape'].message_type = _POINT
 _INFOPERMSOA.fields_by_name['buildings'].message_type = _POINT
+_INFOPERMSOA.fields_by_name['flows_per_activity'].message_type = _FLOWS
 _PERSON.fields_by_name['location'].message_type = _POINT
 _PERSON.fields_by_name['demographics'].message_type = _DEMOGRAPHICS
 _PERSON.fields_by_name['health'].message_type = _HEALTH
 _PERSON.fields_by_name['time_use'].message_type = _TIMEUSE
-_PERSON.fields_by_name['flows_per_activity'].message_type = _FLOWS
+_PERSON.fields_by_name['activity_durations'].message_type = _ACTIVITYDURATION
+_ACTIVITYDURATION.fields_by_name['activity'].enum_type = _ACTIVITY
 _DEMOGRAPHICS.fields_by_name['sex'].enum_type = _SEX
 _DEMOGRAPHICS.fields_by_name['origin'].enum_type = _ORIGIN
 _DEMOGRAPHICS.fields_by_name['socioeconomic_classification'].enum_type = _NSSEC5
@@ -1032,6 +1079,7 @@ DESCRIPTOR.message_types_by_name['VenueList'] = _VENUELIST
 DESCRIPTOR.message_types_by_name['InfoPerMSOA'] = _INFOPERMSOA
 DESCRIPTOR.message_types_by_name['Point'] = _POINT
 DESCRIPTOR.message_types_by_name['Person'] = _PERSON
+DESCRIPTOR.message_types_by_name['ActivityDuration'] = _ACTIVITYDURATION
 DESCRIPTOR.message_types_by_name['Demographics'] = _DEMOGRAPHICS
 DESCRIPTOR.message_types_by_name['Health'] = _HEALTH
 DESCRIPTOR.message_types_by_name['TimeUse'] = _TIMEUSE
@@ -1103,6 +1151,13 @@ Person = _reflection.GeneratedProtocolMessageType('Person', (_message.Message,),
   # @@protoc_insertion_point(class_scope:synthpop.Person)
   ))
 _sym_db.RegisterMessage(Person)
+
+ActivityDuration = _reflection.GeneratedProtocolMessageType('ActivityDuration', (_message.Message,), dict(
+  DESCRIPTOR = _ACTIVITYDURATION,
+  __module__ = 'synthpop_pb2'
+  # @@protoc_insertion_point(class_scope:synthpop.ActivityDuration)
+  ))
+_sym_db.RegisterMessage(ActivityDuration)
 
 Demographics = _reflection.GeneratedProtocolMessageType('Demographics', (_message.Message,), dict(
   DESCRIPTOR = _DEMOGRAPHICS,

--- a/src/init/commuting.rs
+++ b/src/init/commuting.rs
@@ -44,8 +44,7 @@ pub fn create_commuting_flows(population: &mut Population, rng: &mut StdRng) -> 
         })
         .collect();
     for (person, venue_id) in matches.into_iter().flatten() {
-        // Assign the one and only workplace
-        population.people[person].flows_per_activity[Activity::Work] = vec![(venue_id, 1.0)];
+        population.people[person].workplace = Some(venue_id);
     }
 
     // Create venues

--- a/src/init/msoas.rs
+++ b/src/init/msoas.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::{BufReader, Write};
 
 use anyhow::Result;
+use enum_map::EnumMap;
 use geo::map_coords::MapCoords;
 use geo::prelude::{BoundingRect, Centroid, Contains};
 use geo::{MultiPolygon, Point};
@@ -78,6 +79,7 @@ fn load_msoa_shapes(msoas: &BTreeSet<MSOA>) -> Result<BTreeMap<MSOA, InfoPerMSOA
                         shape,
                         population: *population as usize,
                         buildings: Vec::new(),
+                        flows_per_activity: EnumMap::default(),
                     },
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,10 @@ pub struct InfoPerMSOA {
     /// residential, commercial? And some areas don't have any buildings mapped yet!
     // TODO Not guaranteed to be non-empty
     pub buildings: Vec<Point<f32>>,
+    /// Per activity, a list of venues where anybody in this MSOA is likely to go do that activity.
+    /// The probabilities sum to 1.
+    // TODO Consider a distribution type to represent this
+    pub flows_per_activity: EnumMap<Activity, Vec<(VenueID, f64)>>,
 }
 
 /// A special type of venue where people live
@@ -97,6 +101,7 @@ pub struct Household {
 pub struct Person {
     pub id: PersonID,
     pub household: VenueID,
+    pub workplace: Option<VenueID>,
     /// This is the centroid of the household's MSOA. It's redundant to store it per person, but
     /// very convenient.
     pub location: Point<f32>,
@@ -111,10 +116,6 @@ pub struct Person {
 
     pub time_use: pb::TimeUse,
 
-    /// Per activity, a list of venues where this person is likely to go do that activity. The
-    /// probabilities sum to 1.
-    // TODO Consider a distribution type to represent this
-    pub flows_per_activity: EnumMap<Activity, Vec<(VenueID, f64)>>,
     /// These sum to 1, representing a fraction of a day
     pub duration_per_activity: EnumMap<Activity, f64>,
 }

--- a/src/protobuf.rs
+++ b/src/protobuf.rs
@@ -6,7 +6,7 @@ use geo::coords_iter::CoordsIter;
 use geo::{Coordinate, Point};
 use prost::Message;
 
-use crate::{pb, Activity, Person, Population, BMI};
+use crate::{pb, Activity, InfoPerMSOA, Population, BMI};
 
 /// Returns the bytes written
 pub fn convert_to_pb(input: &Population, output_path: String) -> Result<usize> {
@@ -29,6 +29,10 @@ pub fn convert_to_pb(input: &Population, output_path: String) -> Result<usize> {
         output.people.push(pb::Person {
             id: person.id.0.try_into()?,
             household: person.household.0.try_into()?,
+            workplace: match person.workplace {
+                Some(id) => id.0.try_into()?,
+                None => u64::MAX,
+            },
             location: Some(convert_point(&person.location)),
             orig_pid: person.orig_pid.try_into()?,
             demographics: Some(person.demographics.clone()),
@@ -48,7 +52,14 @@ pub fn convert_to_pb(input: &Population, output_path: String) -> Result<usize> {
                 has_high_blood_pressure: person.has_high_blood_pressure,
             }),
             time_use: Some(person.time_use.clone()),
-            flows_per_activity: convert_flows(person),
+            activity_durations: person
+                .duration_per_activity
+                .iter()
+                .map(|(activity, duration)| pb::ActivityDuration {
+                    activity: convert_activity(activity).into(),
+                    duration: *duration,
+                })
+                .collect(),
         });
     }
 
@@ -75,6 +86,7 @@ pub fn convert_to_pb(input: &Population, output_path: String) -> Result<usize> {
                 shape: info.shape.coords_iter().map(convert_coordinate).collect(),
                 population: info.population.try_into()?,
                 buildings: info.buildings.iter().map(convert_point).collect(),
+                flows_per_activity: convert_flows(info),
             },
         );
     }
@@ -101,12 +113,11 @@ fn convert_coordinate(pt: Coordinate<f32>) -> pb::Point {
     }
 }
 
-fn convert_flows(person: &Person) -> Vec<pb::Flows> {
+fn convert_flows(msoa: &InfoPerMSOA) -> Vec<pb::Flows> {
     let mut output = Vec::new();
-    for (activity, flows) in &person.flows_per_activity {
+    for (activity, flows) in &msoa.flows_per_activity {
         output.push(pb::Flows {
             activity: convert_activity(activity).into(),
-            activity_duration: person.duration_per_activity[activity],
             flows: flows
                 .iter()
                 .map(|(venue, weight)| pb::Flow {

--- a/synthpop.proto
+++ b/synthpop.proto
@@ -34,6 +34,7 @@ message InfoPerMSOA {
     uint64 population = 2;
     // All building centroids within this MSOA. Guaranteed to be non-empty.
     repeated Point buildings = 3;
+    repeated Flows flows_per_activity = 4;
 }
 
 // In WGS84
@@ -45,17 +46,25 @@ message Point {
 message Person {
     uint64 id = 1;
     uint64 household = 2;
+    // This indexes into venues_per_activity[Activity::WORK]. This is optional;
+    // somebody who doesn't work will have 2^64 - 1 here.
+    uint64 workplace = 3;
     // This is the centroid of the household's MSOA. It's redundant to store it per person, but
     // very convenient.
-    Point location = 3;
+    Point location = 4;
     // An ID from the original data, kept around for debugging
-    int64 orig_pid = 4;
+    int64 orig_pid = 5;
 
-    Demographics demographics = 5;
-    Health health = 6;
-    TimeUse time_use = 7;
+    Demographics demographics = 6;
+    Health health = 7;
+    TimeUse time_use = 8;
+    repeated ActivityDuration activity_durations = 9;
+}
 
-    repeated Flows flows_per_activity = 8;
+// What fraction of a day somebody spends doing an activity.
+message ActivityDuration {
+    Activity activity = 1;
+    double duration = 2;
 }
 
 message Demographics {
@@ -139,12 +148,13 @@ message TimeUse {
     double home_total = 12;
 }
 
-// Per activity, a list of venues where this person is likely to go do that activity.
+// Per activity, a list of venues where anybody living in a certain MSOA is
+// likely to go do that activity.
 message Flows {
+    // Note that HOME and WORK won't be represented here, since it varies
+    // per-person.
     Activity activity = 1;
     repeated Flow flows = 2;
-    // These sum to 1 for all `flows_per_activity`, representing a fraction of a day
-    double activity_duration = 3;
 }
 
 message Flow {


### PR DESCRIPTION
wasteful in memory and output file size. The consumer can do the lookup
easily on their end.

The resulting schema in the protobuf doesn't feel complicated, based on the changes over in ASPICS: https://github.com/dabreegster/ua-aspics/tree/flows_per_msoa

The most clear benefit comes from performance. The file size for London drops from 3 to 1GB, with peak memory usage from 5 to 2GB! #6 